### PR TITLE
feat: 認証機能の完全実装 🔐

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,13 @@
 # やさいせんせい 環境変数テンプレート
 # このファイルをコピーして .env として保存し、実際の値を設定してください
+# 
+# 🚨 重要: このファイルは .gitignore で除外されています
+# 実際のAPIキーやパスワードは絶対にGitにコミットしないでください
 
 # Supabase設定
 SUPABASE_URL=https://ssrfnkanoegmflgcvkpv.supabase.co
-SUPABASE_ANON_KEY=your_supabase_anon_key
-SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
+SUPABASE_ANON_KEY=your_supabase_anon_key_here
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key_here
 
 # OpenAI API設定（AI相談機能用）
 OPENAI_API_KEY=your_openai_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,19 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Environment variables and secrets
+.env
+.env.local
+.env.development
+.env.production
+*.env
+config/secrets.dart
+
+# API keys and sensitive data
+**/secrets/
+**/keys/
+**/*.key
+**/*.pem
+**/google-services.json
+**/GoogleService-Info.plist

--- a/README.md
+++ b/README.md
@@ -1,17 +1,96 @@
-# vegetable_teacher_app
+# やさいせんせい 🌱
 
-A new Flutter project.
+家庭菜園初心者向けの栽培管理アプリ。植え方から収穫まで、適切なタイミングで通知し、AIに相談もできる。
 
-## Getting Started
+## 🚀 セットアップ
 
-This project is a starting point for a Flutter application.
+### 前提条件
+- Flutter SDK (3.7.2以上)
+- Android Studio / VS Code
+- Supabaseアカウント
 
-A few resources to get you started if this is your first Flutter project:
+### 環境変数の設定
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+1. `.env.example` をコピーして `.env` を作成
+```bash
+cp .env.example .env
+```
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
-# vegetable_teacher
+2. `.env` ファイルに実際の値を設定
+```bash
+# 必須設定
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key-here
+```
+
+3. Supabaseの設定
+   - [Supabase](https://supabase.com)でプロジェクトを作成
+   - Settings → API からURL・キーを取得
+   - **⚠️ 重要**: APIキーは絶対にGitにコミットしないでください
+
+### ビルド・実行
+
+#### 開発環境での実行
+```bash
+# 依存関係のインストール
+flutter pub get
+
+# 環境変数を指定してデバッグ実行
+flutter run --dart-define=SUPABASE_ANON_KEY=your-key-here
+```
+
+#### 本番ビルド
+```bash
+# APKビルド
+flutter build apk --dart-define=SUPABASE_ANON_KEY=your-key-here
+
+# AABビルド（Google Play用）
+flutter build appbundle --dart-define=SUPABASE_ANON_KEY=your-key-here
+```
+
+## 🏗️ 技術スタック
+
+- **フロントエンド**: Flutter
+- **バックエンド**: Supabase (PostgreSQL)
+- **認証**: Supabase Auth
+- **ストレージ**: Supabase Storage
+- **AI機能**: OpenAI API (予定)
+- **通知**: Firebase Cloud Messaging
+
+## 📱 主要機能
+
+### 実装済み
+- ✅ 認証機能（サインアップ・ログイン）
+- ✅ 認証状態管理
+- ✅ 基本的なUI・テーマ
+
+### 開発予定
+- 🔄 野菜管理機能
+- 🔄 栽培スケジュール・通知
+- 🔄 AI相談機能
+- 🔄 成長記録・写真管理
+
+## 🔐 セキュリティ
+
+- API キーは環境変数で管理
+- 機密情報は `.gitignore` で除外
+- カスタムURIスキームで認証フロー保護
+
+## 📖 開発ドキュメント
+
+詳細な仕様は `docs/` フォルダを参照：
+- [設計書](docs/design.md)
+- [開発ロードマップ](docs/roadmap.md)
+- [プロジェクト仕様](CLAUDE.md)
+
+## 🤝 コントリビューション
+
+1. このリポジトリをfork
+2. 機能ブランチを作成 (`git checkout -b feature/amazing-feature`)
+3. 変更をコミット (`git commit -m 'Add amazing feature'`)
+4. ブランチにpush (`git push origin feature/amazing-feature`)
+5. Pull Requestを作成
+
+## 📄 ライセンス
+
+このプロジェクトはMITライセンスの下で公開されています。

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="vegetable_teacher_app"
         android:name="${applicationName}"
@@ -23,6 +24,13 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <!-- Supabase認証用のカスタムURIスキーム -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="com.atsudev.vegetable-teacher" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -10,7 +10,7 @@ import '../../screens/auth/signup_screen.dart';
 class AppRouter {
   static GoRouter createRouter() {
     return GoRouter(
-      initialLocation: '/login',
+      initialLocation: '/',
       routes: [
         // 認証画面
         GoRoute(
@@ -59,6 +59,12 @@ class AppRouter {
         final authProvider = Provider.of<AuthProvider>(context, listen: false);
         final isAuthenticating = state.matchedLocation == '/login' || 
                                  state.matchedLocation == '/signup';
+        final isSplash = state.matchedLocation == '/';
+        
+        // スプラッシュ画面はリダイレクト対象外（自身で認証判定を行うため）
+        if (isSplash) {
+          return null;
+        }
         
         // 認証済みユーザーが認証画面にアクセスしようとした場合、ホームに転送
         if (authProvider.isAuthenticated && isAuthenticating) {
@@ -66,7 +72,7 @@ class AppRouter {
         }
         
         // 未認証ユーザーが保護されたページにアクセスしようとした場合、ログイン画面に転送
-        if (!authProvider.isAuthenticated && !isAuthenticating && state.matchedLocation != '/') {
+        if (!authProvider.isAuthenticated && !isAuthenticating) {
           return '/login';
         }
         

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/auth_provider.dart';
+import '../../screens/auth/login_screen.dart';
+import '../../screens/auth/signup_screen.dart';
+
+/// アプリ全体のルーティング設定
+class AppRouter {
+  static GoRouter createRouter() {
+    return GoRouter(
+      initialLocation: '/login',
+      routes: [
+        // 認証画面
+        GoRoute(
+          path: '/login',
+          name: 'login',
+          pageBuilder: (context, state) => MaterialPage(
+            key: state.pageKey,
+            child: const LoginScreen(),
+          ),
+        ),
+        GoRoute(
+          path: '/signup',
+          name: 'signup',
+          pageBuilder: (context, state) => MaterialPage(
+            key: state.pageKey,
+            child: const SignupScreen(),
+          ),
+        ),
+        // ホーム画面（将来実装）
+        GoRoute(
+          path: '/home',
+          name: 'home',
+          pageBuilder: (context, state) => MaterialPage(
+            key: state.pageKey,
+            child: const PlaceholderHomeScreen(),
+          ),
+          redirect: (context, state) {
+            final authProvider = Provider.of<AuthProvider>(context, listen: false);
+            if (!authProvider.isAuthenticated) {
+              return '/login';
+            }
+            return null;
+          },
+        ),
+        // スプラッシュ画面（将来実装）
+        GoRoute(
+          path: '/',
+          name: 'splash',
+          pageBuilder: (context, state) => MaterialPage(
+            key: state.pageKey,
+            child: const SplashScreen(),
+          ),
+        ),
+      ],
+      redirect: (context, state) {
+        final authProvider = Provider.of<AuthProvider>(context, listen: false);
+        final isAuthenticating = state.matchedLocation == '/login' || 
+                                 state.matchedLocation == '/signup';
+        
+        // 認証済みユーザーが認証画面にアクセスしようとした場合、ホームに転送
+        if (authProvider.isAuthenticated && isAuthenticating) {
+          return '/home';
+        }
+        
+        // 未認証ユーザーが保護されたページにアクセスしようとした場合、ログイン画面に転送
+        if (!authProvider.isAuthenticated && !isAuthenticating && state.matchedLocation != '/') {
+          return '/login';
+        }
+        
+        return null;
+      },
+      errorPageBuilder: (context, state) => MaterialPage(
+        key: state.pageKey,
+        child: Scaffold(
+          body: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Icon(Icons.error_outline, size: 64, color: Colors.red),
+                const SizedBox(height: 16),
+                Text(
+                  'ページが見つかりません',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'URL: ${state.uri}',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: () => context.go('/'),
+                  child: const Text('ホームに戻る'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// プレースホルダーのホーム画面
+class PlaceholderHomeScreen extends StatelessWidget {
+  const PlaceholderHomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('やさいせんせい'),
+        backgroundColor: Theme.of(context).primaryColor,
+        foregroundColor: Colors.white,
+        actions: [
+          IconButton(
+            onPressed: () {
+              final authProvider = Provider.of<AuthProvider>(context, listen: false);
+              authProvider.signOut();
+              context.go('/login');
+            },
+            icon: const Icon(Icons.logout),
+          ),
+        ],
+      ),
+      body: const Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.eco, size: 100, color: Colors.green),
+            SizedBox(height: 24),
+            Text(
+              'ホーム画面',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            SizedBox(height: 16),
+            Text(
+              'ログイン成功！\n今後はここに野菜管理機能を実装します。',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 16),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// スプラッシュ画面
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    _checkAuthStatus();
+  }
+
+  Future<void> _checkAuthStatus() async {
+    // スプラッシュ画面を2秒表示
+    await Future.delayed(const Duration(seconds: 2));
+    
+    if (mounted) {
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      if (authProvider.isAuthenticated) {
+        context.go('/home');
+      } else {
+        context.go('/login');
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).primaryColor,
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(
+              Icons.eco,
+              size: 100,
+              color: Colors.white,
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'やさいせんせい',
+              style: Theme.of(context).textTheme.headlineLarge?.copyWith(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              '家庭菜園を始めよう',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 18,
+              ),
+            ),
+            const SizedBox(height: 48),
+            const CircularProgressIndicator(
+              valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-// import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'core/themes/app_theme.dart';
 import 'core/constants/app_constants.dart';
+import 'core/router/app_router.dart';
 import 'providers/auth_provider.dart';
 import 'providers/vegetable_provider.dart';
 import 'providers/notification_provider.dart';
@@ -11,17 +12,19 @@ import 'providers/notification_provider.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   
-  // 一時的にSupabase初期化をコメントアウト（キーが設定されていないため）
-  // await Supabase.initialize(
-  //   url: AppConstants.supabaseUrl,
-  //   anonKey: AppConstants.supabaseAnonKey,
-  // );
+  // Supabase初期化
+  await Supabase.initialize(
+    url: AppConstants.supabaseUrl,
+    anonKey: AppConstants.supabaseAnonKey.isNotEmpty 
+        ? AppConstants.supabaseAnonKey 
+        : 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNzcmZua2Fub2VnbWZsZ2N2a3B2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3MjEzMDQ5MjUsImV4cCI6MjAzNjg4MDkyNX0.7y2JBmCrJ8l5bJBmhNgKCqfIVfNyEqhVOlXJrGJ8TfM',
+  );
   
   runApp(const VegetableTeacherApp());
 }
 
 class VegetableTeacherApp extends StatelessWidget {
-  const VegetableTeacherApp({Key? key}) : super(key: key);
+  const VegetableTeacherApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -31,42 +34,14 @@ class VegetableTeacherApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => VegetableProvider()),
         ChangeNotifierProvider(create: (_) => NotificationProvider()),
       ],
-      child: MaterialApp(
+      child: MaterialApp.router(
         title: AppConstants.appName,
         theme: AppTheme.lightTheme,
         darkTheme: AppTheme.darkTheme,
-        home: const SplashScreen(),
+        routerConfig: AppRouter.createRouter(),
         debugShowCheckedModeBanner: false,
       ),
     );
   }
 }
 
-class SplashScreen extends StatelessWidget {
-  const SplashScreen({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.eco,
-              size: 64,
-              color: Theme.of(context).primaryColor,
-            ),
-            const SizedBox(height: 16),
-            Text(
-              AppConstants.appName,
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-            const SizedBox(height: 8),
-            const Text('家庭菜園を始めよう！'),
-          ],
-        ),
-      ),
-    );
-  }
-}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,12 +12,25 @@ import 'providers/notification_provider.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   
+  // 環境変数からSupabaseキーを取得
+  const supabaseUrl = String.fromEnvironment(
+    'SUPABASE_URL',
+    defaultValue: AppConstants.supabaseUrl,
+  );
+  const supabaseAnonKey = String.fromEnvironment('SUPABASE_ANON_KEY');
+  
+  // APIキーの存在チェック
+  if (supabaseAnonKey.isEmpty) {
+    throw Exception(
+      'SUPABASE_ANON_KEY is not configured. '
+      'Please set the environment variable or use --dart-define during build.',
+    );
+  }
+  
   // Supabase初期化
   await Supabase.initialize(
-    url: AppConstants.supabaseUrl,
-    anonKey: AppConstants.supabaseAnonKey.isNotEmpty 
-        ? AppConstants.supabaseAnonKey 
-        : 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNzcmZua2Fub2VnbWZsZ2N2a3B2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3MjEzMDQ5MjUsImV4cCI6MjAzNjg4MDkyNX0.7y2JBmCrJ8l5bJBmhNgKCqfIVfNyEqhVOlXJrGJ8TfM',
+    url: supabaseUrl,
+    anonKey: supabaseAnonKey,
   );
   
   runApp(const VegetableTeacherApp());

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -1,37 +1,137 @@
 import 'package:flutter/foundation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../core/services/supabase_service.dart';
 
-/// 認証状態管理プロバイダー（基本実装）
+/// 認証状態管理プロバイダー
 class AuthProvider extends ChangeNotifier {
   bool _isLoading = false;
   String? _errorMessage;
-  bool _isAuthenticated = false;
+  User? _currentUser;
 
   // Getters
   bool get isLoading => _isLoading;
   String? get errorMessage => _errorMessage;
-  bool get isAuthenticated => _isAuthenticated;
+  bool get isAuthenticated => _currentUser != null;
+  User? get currentUser => _currentUser;
 
   AuthProvider() {
     _init();
   }
 
   void _init() {
-    // 初期化処理（後でSupabase実装時に追加）
+    // 現在のユーザー状態を取得
+    _currentUser = SupabaseService.currentUser;
+    
+    // 認証状態の変更を監視
+    SupabaseService.authStateChanges.listen((AuthState data) {
+      _currentUser = data.session?.user;
+      notifyListeners();
+    });
   }
 
-  /// サインイン（ダミー実装）
-  Future<void> signIn(String email, String password) async {
-    _setLoading(true);
-    // ダミー処理
-    await Future.delayed(const Duration(seconds: 1));
-    _isAuthenticated = true;
-    _setLoading(false);
+  /// メール・パスワードでサインアップ
+  Future<bool> signUp(String email, String password) async {
+    try {
+      _setLoading(true);
+      clearError();
+
+      final AuthResponse response = await SupabaseService.client.auth.signUp(
+        email: email,
+        password: password,
+      );
+
+      if (response.user != null) {
+        _currentUser = response.user;
+        return true;
+      } else {
+        _setError('アカウント作成に失敗しました');
+        return false;
+      }
+    } on AuthException catch (e) {
+      _setError(_getJapaneseErrorMessage(e.message));
+      return false;
+    } catch (e) {
+      _setError('予期しないエラーが発生しました: $e');
+      return false;
+    } finally {
+      _setLoading(false);
+    }
   }
 
-  /// サインアウト（ダミー実装）
+  /// メール・パスワードでサインイン
+  Future<bool> signIn(String email, String password) async {
+    try {
+      _setLoading(true);
+      clearError();
+
+      final AuthResponse response = await SupabaseService.client.auth.signInWithPassword(
+        email: email,
+        password: password,
+      );
+
+      if (response.user != null) {
+        _currentUser = response.user;
+        return true;
+      } else {
+        _setError('ログインに失敗しました');
+        return false;
+      }
+    } on AuthException catch (e) {
+      _setError(_getJapaneseErrorMessage(e.message));
+      return false;
+    } catch (e) {
+      _setError('予期しないエラーが発生しました: $e');
+      return false;
+    } finally {
+      _setLoading(false);
+    }
+  }
+
+  /// パスワードリセット
+  Future<bool> resetPassword(String email) async {
+    try {
+      _setLoading(true);
+      clearError();
+
+      await SupabaseService.client.auth.resetPasswordForEmail(
+        email,
+        redirectTo: 'com.atsudev.vegetable-teacher://reset-password',
+      );
+
+      return true;
+    } on AuthException catch (e) {
+      _setError(_getJapaneseErrorMessage(e.message));
+      return false;
+    } catch (e) {
+      _setError('予期しないエラーが発生しました: $e');
+      return false;
+    } finally {
+      _setLoading(false);
+    }
+  }
+
+  /// サインアウト
   Future<void> signOut() async {
-    _isAuthenticated = false;
-    notifyListeners();
+    try {
+      _setLoading(true);
+      await SupabaseService.client.auth.signOut();
+      _currentUser = null;
+    } catch (e) {
+      _setError('ログアウトに失敗しました: $e');
+    } finally {
+      _setLoading(false);
+    }
+  }
+
+  /// セッション更新
+  Future<void> refreshSession() async {
+    try {
+      await SupabaseService.client.auth.refreshSession();
+      _currentUser = SupabaseService.currentUser;
+      notifyListeners();
+    } catch (e) {
+      debugPrint('セッション更新エラー: $e');
+    }
   }
 
   void _setLoading(bool loading) {
@@ -47,5 +147,27 @@ class AuthProvider extends ChangeNotifier {
   void clearError() {
     _errorMessage = null;
     notifyListeners();
+  }
+
+  /// Supabaseエラーメッセージを日本語に変換
+  String _getJapaneseErrorMessage(String message) {
+    switch (message.toLowerCase()) {
+      case 'invalid login credentials':
+        return 'メールアドレスまたはパスワードが正しくありません';
+      case 'user not found':
+        return 'ユーザーが見つかりません';
+      case 'email already registered':
+        return 'このメールアドレスは既に登録されています';
+      case 'password should be at least 6 characters':
+        return 'パスワードは6文字以上で入力してください';
+      case 'invalid email':
+        return '有効なメールアドレスを入力してください';
+      case 'signup disabled':
+        return '現在新規登録は無効になっています';
+      case 'too many requests':
+        return 'リクエストが多すぎます。しばらく待ってからお試しください';
+      default:
+        return message;
+    }
   }
 }

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -131,8 +131,10 @@ class AuthProvider extends ChangeNotifier {
       await SupabaseService.client.auth.refreshSession();
       _currentUser = SupabaseService.currentUser;
       notifyListeners();
+    } on AuthException catch (e) {
+      _setError(_getJapaneseErrorMessage(e.message));
     } catch (e) {
-      debugPrint('セッション更新エラー: $e');
+      _setError('セッション更新に失敗しました: $e');
     }
   }
 

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../core/services/supabase_service.dart';
@@ -7,6 +8,7 @@ class AuthProvider extends ChangeNotifier {
   bool _isLoading = false;
   String? _errorMessage;
   User? _currentUser;
+  StreamSubscription<AuthState>? _authSubscription;
 
   // Getters
   bool get isLoading => _isLoading;
@@ -22,8 +24,8 @@ class AuthProvider extends ChangeNotifier {
     // 現在のユーザー状態を取得
     _currentUser = SupabaseService.currentUser;
     
-    // 認証状態の変更を監視
-    SupabaseService.authStateChanges.listen((AuthState data) {
+    // 認証状態の変更を監視（StreamSubscriptionを保存）
+    _authSubscription = SupabaseService.authStateChanges.listen((AuthState data) {
       _currentUser = data.session?.user;
       notifyListeners();
     });
@@ -169,5 +171,12 @@ class AuthProvider extends ChangeNotifier {
       default:
         return message;
     }
+  }
+
+  @override
+  void dispose() {
+    // StreamSubscriptionをキャンセルしてメモリリークを防止
+    _authSubscription?.cancel();
+    super.dispose();
   }
 }

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:go_router/go_router.dart';
+import '../../providers/auth_provider.dart';
+import '../../core/themes/app_colors.dart';
+import '../../core/themes/app_text_styles.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _obscurePassword = true;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: Consumer<AuthProvider>(
+          builder: (context, authProvider, child) {
+            return Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // アプリロゴとタイトル
+                  Column(
+                    children: [
+                      Icon(
+                        Icons.eco,
+                        size: 80,
+                        color: AppColors.primary,
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        'やさいせんせい',
+                        style: AppTextStyles.headline1.copyWith(
+                          color: AppColors.primary,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        '家庭菜園を始めよう',
+                        style: AppTextStyles.body1.copyWith(
+                          color: AppColors.onBackground,
+                        ),
+                      ),
+                    ],
+                  ),
+                  
+                  const SizedBox(height: 48),
+                  
+                  // ログインフォーム
+                  Form(
+                    key: _formKey,
+                    child: Column(
+                      children: [
+                        // メールアドレス入力
+                        TextFormField(
+                          controller: _emailController,
+                          keyboardType: TextInputType.emailAddress,
+                          decoration: InputDecoration(
+                            labelText: 'メールアドレス',
+                            prefixIcon: const Icon(Icons.email_outlined),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                          ),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'メールアドレスを入力してください';
+                            }
+                            if (!RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$').hasMatch(value)) {
+                              return '有効なメールアドレスを入力してください';
+                            }
+                            return null;
+                          },
+                        ),
+                        
+                        const SizedBox(height: 16),
+                        
+                        // パスワード入力
+                        TextFormField(
+                          controller: _passwordController,
+                          obscureText: _obscurePassword,
+                          decoration: InputDecoration(
+                            labelText: 'パスワード',
+                            prefixIcon: const Icon(Icons.lock_outlined),
+                            suffixIcon: IconButton(
+                              onPressed: () {
+                                setState(() {
+                                  _obscurePassword = !_obscurePassword;
+                                });
+                              },
+                              icon: Icon(
+                                _obscurePassword
+                                    ? Icons.visibility_outlined
+                                    : Icons.visibility_off_outlined,
+                              ),
+                            ),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                          ),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'パスワードを入力してください';
+                            }
+                            if (value.length < 6) {
+                              return 'パスワードは6文字以上で入力してください';
+                            }
+                            return null;
+                          },
+                        ),
+                        
+                        const SizedBox(height: 24),
+                        
+                        // エラーメッセージ表示
+                        if (authProvider.errorMessage != null)
+                          Container(
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: Colors.red.shade50,
+                              borderRadius: BorderRadius.circular(8),
+                              border: Border.all(color: Colors.red.shade200),
+                            ),
+                            child: Row(
+                              children: [
+                                Icon(Icons.error_outline, color: Colors.red.shade600),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    authProvider.errorMessage!,
+                                    style: TextStyle(color: Colors.red.shade600),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        
+                        if (authProvider.errorMessage != null)
+                          const SizedBox(height: 16),
+                        
+                        // ログインボタン
+                        SizedBox(
+                          width: double.infinity,
+                          height: 48,
+                          child: ElevatedButton(
+                            onPressed: authProvider.isLoading ? null : _handleLogin,
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: AppColors.primary,
+                              foregroundColor: Colors.white,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                            ),
+                            child: authProvider.isLoading
+                                ? const SizedBox(
+                                    width: 20,
+                                    height: 20,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                                    ),
+                                  )
+                                : const Text(
+                                    'ログイン',
+                                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                                  ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  
+                  const SizedBox(height: 24),
+                  
+                  // パスワードリセットリンク
+                  TextButton(
+                    onPressed: authProvider.isLoading ? null : _handleResetPassword,
+                    child: Text(
+                      'パスワードを忘れた方はこちら',
+                      style: AppTextStyles.body2.copyWith(
+                        color: AppColors.primary,
+                      ),
+                    ),
+                  ),
+                  
+                  const SizedBox(height: 16),
+                  
+                  // サインアップリンク
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        'アカウントをお持ちでない方は',
+                        style: AppTextStyles.body2.copyWith(
+                          color: AppColors.onBackground,
+                        ),
+                      ),
+                      TextButton(
+                        onPressed: authProvider.isLoading ? null : () {
+                          context.push('/signup');
+                        },
+                        child: Text(
+                          '新規登録',
+                          style: AppTextStyles.body2.copyWith(
+                            color: AppColors.primary,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleLogin() async {
+    if (_formKey.currentState!.validate()) {
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      authProvider.clearError();
+      
+      final success = await authProvider.signIn(
+        _emailController.text.trim(),
+        _passwordController.text,
+      );
+      
+      if (success && mounted) {
+        context.go('/home');
+      }
+    }
+  }
+
+  Future<void> _handleResetPassword() async {
+    if (_emailController.text.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('パスワードリセットにはメールアドレスが必要です'),
+        ),
+      );
+      return;
+    }
+
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
+    final success = await authProvider.resetPassword(_emailController.text.trim());
+    
+    if (success && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('パスワードリセットメールを送信しました'),
+          backgroundColor: Colors.green,
+        ),
+      );
+    }
+  }
+}

--- a/lib/screens/auth/signup_screen.dart
+++ b/lib/screens/auth/signup_screen.dart
@@ -1,0 +1,343 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:go_router/go_router.dart';
+import '../../providers/auth_provider.dart';
+import '../../core/themes/app_colors.dart';
+import '../../core/themes/app_text_styles.dart';
+
+class SignupScreen extends StatefulWidget {
+  const SignupScreen({super.key});
+
+  @override
+  State<SignupScreen> createState() => _SignupScreenState();
+}
+
+class _SignupScreenState extends State<SignupScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+  bool _obscurePassword = true;
+  bool _obscureConfirmPassword = true;
+  bool _agreeToTerms = false;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          onPressed: () => context.pop(),
+          icon: Icon(Icons.arrow_back, color: AppColors.primary),
+        ),
+        title: Text(
+          '新規登録',
+          style: AppTextStyles.headline2.copyWith(
+            color: AppColors.primary,
+          ),
+        ),
+      ),
+      body: SafeArea(
+        child: Consumer<AuthProvider>(
+          builder: (context, authProvider, child) {
+            return SingleChildScrollView(
+              padding: const EdgeInsets.all(24.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // 説明テキスト
+                  Column(
+                    children: [
+                      Icon(
+                        Icons.eco,
+                        size: 60,
+                        color: AppColors.primary,
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        '野菜作りを始めましょう',
+                        style: AppTextStyles.headline2.copyWith(
+                          color: AppColors.onSurface,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'メールアドレスとパスワードを設定して\nアカウントを作成してください',
+                        style: AppTextStyles.body2.copyWith(
+                          color: AppColors.onBackground,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ),
+                  
+                  const SizedBox(height: 32),
+                  
+                  // サインアップフォーム
+                  Form(
+                    key: _formKey,
+                    child: Column(
+                      children: [
+                        // メールアドレス入力
+                        TextFormField(
+                          controller: _emailController,
+                          keyboardType: TextInputType.emailAddress,
+                          decoration: InputDecoration(
+                            labelText: 'メールアドレス',
+                            prefixIcon: const Icon(Icons.email_outlined),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                          ),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'メールアドレスを入力してください';
+                            }
+                            if (!RegExp(r'^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$').hasMatch(value)) {
+                              return '有効なメールアドレスを入力してください';
+                            }
+                            return null;
+                          },
+                        ),
+                        
+                        const SizedBox(height: 16),
+                        
+                        // パスワード入力
+                        TextFormField(
+                          controller: _passwordController,
+                          obscureText: _obscurePassword,
+                          decoration: InputDecoration(
+                            labelText: 'パスワード',
+                            helperText: '6文字以上で入力してください',
+                            prefixIcon: const Icon(Icons.lock_outlined),
+                            suffixIcon: IconButton(
+                              onPressed: () {
+                                setState(() {
+                                  _obscurePassword = !_obscurePassword;
+                                });
+                              },
+                              icon: Icon(
+                                _obscurePassword
+                                    ? Icons.visibility_outlined
+                                    : Icons.visibility_off_outlined,
+                              ),
+                            ),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                          ),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'パスワードを入力してください';
+                            }
+                            if (value.length < 6) {
+                              return 'パスワードは6文字以上で入力してください';
+                            }
+                            return null;
+                          },
+                        ),
+                        
+                        const SizedBox(height: 16),
+                        
+                        // パスワード確認入力
+                        TextFormField(
+                          controller: _confirmPasswordController,
+                          obscureText: _obscureConfirmPassword,
+                          decoration: InputDecoration(
+                            labelText: 'パスワード確認',
+                            prefixIcon: const Icon(Icons.lock_outlined),
+                            suffixIcon: IconButton(
+                              onPressed: () {
+                                setState(() {
+                                  _obscureConfirmPassword = !_obscureConfirmPassword;
+                                });
+                              },
+                              icon: Icon(
+                                _obscureConfirmPassword
+                                    ? Icons.visibility_outlined
+                                    : Icons.visibility_off_outlined,
+                              ),
+                            ),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                          ),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'パスワード確認を入力してください';
+                            }
+                            if (value != _passwordController.text) {
+                              return 'パスワードが一致しません';
+                            }
+                            return null;
+                          },
+                        ),
+                        
+                        const SizedBox(height: 24),
+                        
+                        // 利用規約同意チェックボックス
+                        Row(
+                          children: [
+                            Checkbox(
+                              value: _agreeToTerms,
+                              onChanged: (value) {
+                                setState(() {
+                                  _agreeToTerms = value ?? false;
+                                });
+                              },
+                              activeColor: AppColors.primary,
+                            ),
+                            Expanded(
+                              child: GestureDetector(
+                                onTap: () {
+                                  setState(() {
+                                    _agreeToTerms = !_agreeToTerms;
+                                  });
+                                },
+                                child: RichText(
+                                  text: TextSpan(
+                                    style: AppTextStyles.caption.copyWith(
+                                      color: AppColors.onBackground,
+                                    ),
+                                    children: [
+                                      const TextSpan(text: '利用規約とプライバシーポリシーに同意します'),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        
+                        const SizedBox(height: 24),
+                        
+                        // エラーメッセージ表示
+                        if (authProvider.errorMessage != null)
+                          Container(
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: Colors.red.shade50,
+                              borderRadius: BorderRadius.circular(8),
+                              border: Border.all(color: Colors.red.shade200),
+                            ),
+                            child: Row(
+                              children: [
+                                Icon(Icons.error_outline, color: Colors.red.shade600),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    authProvider.errorMessage!,
+                                    style: TextStyle(color: Colors.red.shade600),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        
+                        if (authProvider.errorMessage != null)
+                          const SizedBox(height: 16),
+                        
+                        // サインアップボタン
+                        SizedBox(
+                          width: double.infinity,
+                          height: 48,
+                          child: ElevatedButton(
+                            onPressed: authProvider.isLoading || !_agreeToTerms ? null : _handleSignup,
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: AppColors.primary,
+                              foregroundColor: Colors.white,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                            ),
+                            child: authProvider.isLoading
+                                ? const SizedBox(
+                                    width: 20,
+                                    height: 20,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                                    ),
+                                  )
+                                : const Text(
+                                    'アカウント作成',
+                                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                                  ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  
+                  const SizedBox(height: 24),
+                  
+                  // ログインリンク
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        'すでにアカウントをお持ちの方は',
+                        style: AppTextStyles.body2.copyWith(
+                          color: AppColors.onBackground,
+                        ),
+                      ),
+                      TextButton(
+                        onPressed: authProvider.isLoading ? null : () {
+                          context.pop();
+                        },
+                        child: Text(
+                          'ログイン',
+                          style: AppTextStyles.body2.copyWith(
+                            color: AppColors.primary,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleSignup() async {
+    if (_formKey.currentState!.validate()) {
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      authProvider.clearError();
+      
+      final success = await authProvider.signUp(
+        _emailController.text.trim(),
+        _passwordController.text,
+      );
+      
+      if (success && mounted) {
+        // 成功メッセージを表示
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('アカウントが作成されました！確認メールをチェックしてください'),
+            backgroundColor: Colors.green,
+            duration: Duration(seconds: 3),
+          ),
+        );
+        
+        // ホーム画面に遷移
+        context.go('/home');
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 概要
やさいせんせい（家庭菜園アプリ）の認証機能を完全実装しました。
ユーザーが安心して使えるアプリの基盤が完成！

## 実装内容

### 🤖 Android設定
- AndroidManifest.xmlにINTERNET権限を追加  
- Supabase認証用カスタムURIスキーム（`com.atsudev.vegetable-teacher://`）設定

### 🔐 認証プロバイダー
- **AuthProvider**にSupabase Auth完全連携
- サインアップ・サインイン・パスワードリセット機能
- セッション管理と自動ログイン
- **日本語エラーメッセージ対応**（野菜作り初心者でも分かりやすく）

### 🎨 UI実装
- **ログイン画面**: バリデーション・UX最適化
- **サインアップ画面**: パスワード確認・利用規約同意
- 既存テーマシステム（AppColors, AppTextStyles）との統合

### 🛣️ ルーティング
- **go_router**による認証ガード実装
- 認証状態による自動画面遷移
- スプラッシュ画面とプレースホルダーホーム画面

### ✅ 動作確認
- APKビルド成功
- 認証フロー完全動作確認済み

## テスト計画
- [x] サインアップフロー
- [x] サインインフロー  
- [x] パスワードリセット
- [x] 自動ログイン
- [x] 認証ガード
- [x] エラーハンドリング

## 次のステップ
- 野菜管理画面の実装
- AI相談機能（Python FastAPI）
- プッシュ通知機能

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced login and signup screens with form validation, password visibility toggles, error display, and navigation.
  * Added password reset functionality from the login screen.
  * Implemented app-wide routing with authentication-aware redirects and error handling for unknown routes.
  * Added placeholder home screen for improved navigation flow.

* **Improvements**
  * Enhanced authentication provider to fully support Supabase authentication, including localized Japanese error messages and robust state management.
  * Updated app initialization and routing to use a declarative router configuration with environment-based Supabase setup.
  * Removed the previously used splash screen widget as part of routing improvements.

* **Chores**
  * Updated Android permissions and intent filters to support internet access and Supabase authentication via a custom URI scheme.
  * Expanded `.gitignore` to exclude environment and secret files.
  * Revised README with comprehensive project documentation and setup instructions in Japanese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->