### PR TITLE
fix: パッケージ名の不整合を解消してGoogle認証エラーを修正

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="com.atsudev.vegetable-teacher" />
+                <data android:scheme="com.atsudev.vegetable_teacher_app" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/claude.md
+++ b/claude.md
@@ -17,7 +17,7 @@
 - **ストレージ**: Supabase Storage
 - **プッシュ通知**: Supabase Functions + FCM
 - **AI**: OpenAI API (GPT-4o-mini)
-- **パッケージ名**: com.atsudev.vegetable-teacher
+- **パッケージ名**: com.atsudev.vegetable_teacher_app
 
 ## 主要機能
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@
 
 ### 開発環境
 - **Supabaseプロジェクト**: やさいせんせい-dev (ssrfnkanoegmflgcvkpv)
-- **パッケージ名**: com.atsudev.vegetable-teacher
+- **パッケージ名**: com.atsudev.vegetable_teacher_app
 
 ### 外部資料
 - [Supabase Documentation](https://supabase.com/docs)

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -74,7 +74,7 @@ supabase projects list
 
 ### 認証方式
 - Android専用でカスタムURIスキーム採用
-- `com.atsudev.vegetable-teacher://auth/callback`
+- `com.atsudev.vegetable_teacher_app://auth/callback`
 - **判断理由**: モバイルアプリでの認証体験を最適化
 
 ## 🚨 今後注意すべき点

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -16,7 +16,7 @@
 - **認証**: Supabase Auth
 - **ストレージ**: Supabase Storage
 - **AI**: OpenAI GPT-4o-mini
-- **パッケージ名**: `com.atsudev.vegetable-teacher`
+- **パッケージ名**: `com.atsudev.vegetable_teacher_app`
 
 ## 🎯 機能仕様（フェーズ1 MVP）
 
@@ -95,7 +95,7 @@ POST /api/consultation
 
 ### Supabase Auth
 - メール認証
-- カスタムURIスキーム：`com.atsudev.vegetable-teacher://auth/callback`
+- カスタムURIスキーム：`com.atsudev.vegetable_teacher_app://auth/callback`
 
 ## 🔔 通知仕様
 

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -8,7 +8,7 @@ class AppConstants {
   // =====================
   static const String appName = 'やさいせんせい';
   static const String appVersion = '1.0.0';
-  static const String appPackageName = 'com.atsudev.vegetable-teacher';
+  static const String appPackageName = 'com.atsudev.vegetable_teacher_app';
   
   // =====================
   // API・URL関連

--- a/supabase/android_auth_setup.md
+++ b/supabase/android_auth_setup.md
@@ -4,8 +4,8 @@
 やさいせんせいのAndroid向けSupabase認証設定の詳細ガイド
 
 ## 基本情報
-- **パッケージ名**: `com.atsudev.vegetable-teacher`
-- **カスタムURIスキーム**: `com.atsudev.vegetable-teacher://auth/callback`
+- **パッケージ名**: `com.atsudev.vegetable_teacher_app`
+- **カスタムURIスキーム**: `com.atsudev.vegetable_teacher_app://auth/callback`
 - **認証フロー**: PKCE（Proof Key for Code Exchange）
 
 ## 1. Android設定
@@ -107,7 +107,7 @@ android {
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="com.atsudev.vegetable-teacher" />
+                <data android:scheme="com.atsudev.vegetable_teacher_app" />
             </intent-filter>
         </activity>
         
@@ -324,7 +324,7 @@ class DeepLinkHandler {
     final uri = Uri.parse(url);
     
     // 認証コールバックの処理
-    if (uri.scheme == 'com.atsudev.vegetable-teacher' && uri.host == 'auth') {
+    if (uri.scheme == 'com.atsudev.vegetable_teacher_app' && uri.host == 'auth') {
       // Supabaseが自動的に処理
       print('認証コールバックを受信: $url');
     }

--- a/supabase/auth_config.json
+++ b/supabase/auth_config.json
@@ -1,7 +1,7 @@
 {
   "site_settings": {
     "site_name": "やさいせんせい",
-    "site_url": "com.atsudev.vegetable-teacher://auth/callback",
+    "site_url": "com.atsudev.vegetable_teacher_app://auth/callback",
     "additional_redirect_urls": []
   },
   "email_auth": {

--- a/supabase/auth_implementation.md
+++ b/supabase/auth_implementation.md
@@ -44,7 +44,7 @@
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
-        <data android:scheme="com.atsudev.vegetable-teacher" />
+        <data android:scheme="com.atsudev.vegetable_teacher_app" />
     </intent-filter>
 </activity>
 ```

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -11,7 +11,7 @@ max_rows = 1000
 [auth]
 # 認証設定
 enabled = true
-site_url = "com.atsudev.vegetable-teacher://auth/callback"
+site_url = "com.atsudev.vegetable_teacher_app://auth/callback"
 additional_redirect_urls = []
 jwt_expiry = 3600
 enable_signup = true


### PR DESCRIPTION
## 🐛 問題
Google認証でCode 10エラーが発生していた原因を特定・修正しました。

### 根本原因
パッケージ名の不整合：
- **Android設定**: `com.atsudev.vegetable_teacher_app` (アンダースコア)
- **URIスキーム・ドキュメント**: `com.atsudev.vegetable-teacher` (ハイフン)

この1文字の違いにより、Google Cloud ConsoleのAndroid Client IDとアプリの実際のパッケージ名が一致せず、認証に失敗していました。

## ✅ 修正内容

### コードファイル
- `android/app/src/main/AndroidManifest.xml` - URIスキーム統一
- `lib/core/constants/app_constants.dart` - アプリ定数修正
- `supabase/auth_config.json` - リダイレクトURL修正
- `supabase/config.toml` - サイトURL修正

### ドキュメントファイル
- `CLAUDE.md` - 仕様書のパッケージ名修正
- `docs/README.md`, `docs/spec.md`, `docs/notes.md` - ドキュメント統一
- `supabase/android_auth_setup.md`, `supabase/auth_implementation.md` - 技術ドキュメント修正

## 🎯 結果
- ✅ Google認証が正常に動作するように
- ✅ 全ファイルでパッケージ名が `com.atsudev.vegetable_teacher_app` に統一
- ✅ 今後のパッケージ名関連エラーを予防

## 🧪 テスト状況
- ✅ Google認証フローが正常に完了することを確認
- ✅ パッケージ名の不整合が完全に解消されたことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)