### PR TITLE
feat: AI相談機能の実装

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -7,6 +7,8 @@ import '../../screens/auth/login_screen.dart';
 import '../../screens/vegetables/vegetable_list_screen.dart';
 import '../../screens/vegetables/add_vegetable_screen.dart';
 import '../../screens/vegetables/vegetable_detail_screen.dart';
+import '../../screens/ai_chat/ai_chat_screen.dart';
+import '../../models/user_vegetable.dart';
 
 /// アプリ全体のルーティング設定
 class AppRouter {
@@ -91,6 +93,52 @@ class AppRouter {
             return MaterialPage(
               key: state.pageKey,
               child: VegetableDetailScreen(userVegetableId: userVegetableId),
+            );
+          },
+          redirect: (context, state) {
+            final authProvider = Provider.of<AuthProvider>(context, listen: false);
+            if (!authProvider.isAuthenticated) {
+              return '/login';
+            }
+            return null;
+          },
+        ),
+        // AI相談画面
+        GoRoute(
+          path: '/vegetables/:id/chat',
+          name: 'aiChat',
+          pageBuilder: (context, state) {
+            final userVegetableId = state.pathParameters['id'];
+            final userVegetable = state.extra as UserVegetable?;
+            
+            // パラメータの検証
+            if (userVegetableId == null || userVegetableId.isEmpty || userVegetable == null) {
+              return MaterialPage(
+                key: state.pageKey,
+                child: Scaffold(
+                  appBar: AppBar(title: const Text('エラー')),
+                  body: const Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(Icons.error_outline, size: 64, color: Colors.red),
+                        SizedBox(height: 16),
+                        Text(
+                          '野菜情報が見つかりません',
+                          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                        ),
+                        SizedBox(height: 8),
+                        Text('AI相談を開始できませんでした'),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            }
+            
+            return MaterialPage(
+              key: state.pageKey,
+              child: AiChatScreen(userVegetable: userVegetable),
             );
           },
           redirect: (context, state) {

--- a/lib/screens/ai_chat/ai_chat_screen.dart
+++ b/lib/screens/ai_chat/ai_chat_screen.dart
@@ -1,0 +1,459 @@
+import 'package:flutter/material.dart';
+import '../../models/user_vegetable.dart';
+import '../../core/themes/app_colors.dart';
+import '../../core/themes/app_text_styles.dart';
+import '../../services/ai_chat_service.dart';
+import '../../services/consultation_service.dart';
+
+class AiChatScreen extends StatefulWidget {
+  final UserVegetable userVegetable;
+
+  const AiChatScreen({
+    super.key,
+    required this.userVegetable,
+  });
+
+  @override
+  State<AiChatScreen> createState() => _AiChatScreenState();
+}
+
+class _AiChatScreenState extends State<AiChatScreen> {
+  final TextEditingController _messageController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  final AiChatService _aiChatService = AiChatService();
+  final ConsultationService _consultationService = ConsultationService();
+  List<ChatMessage> _messages = [];
+  bool _isLoading = false;
+  bool _canSend = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadChatHistory();
+  }
+
+  @override
+  void dispose() {
+    _messageController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _loadChatHistory() async {
+    try {
+      final chatHistory = await _consultationService.getChatHistory(widget.userVegetable.id);
+      
+      setState(() {
+        if (chatHistory.isEmpty) {
+          _messages = [
+            ChatMessage(
+              message: 'こんにちは！野菜の栽培についてお答えします。何でもお聞きください！',
+              isUser: false,
+              timestamp: DateTime.now(),
+            ),
+          ];
+        } else {
+          _messages = chatHistory;
+        }
+      });
+    } catch (e) {
+      setState(() {
+        _messages = [
+          ChatMessage(
+            message: 'こんにちは！野菜の栽培についてお答えします。何でもお聞きください！',
+            isUser: false,
+            timestamp: DateTime.now(),
+          ),
+        ];
+      });
+    }
+  }
+
+  void _sendMessage() async {
+    if (_messageController.text.trim().isEmpty || !_canSend) return;
+
+    final userMessage = _messageController.text.trim();
+    _messageController.clear();
+
+    setState(() {
+      _messages.add(ChatMessage(
+        message: userMessage,
+        isUser: true,
+        timestamp: DateTime.now(),
+      ));
+      _isLoading = true;
+      _canSend = false;
+    });
+
+    _scrollToBottom();
+
+    try {
+      final response = await _aiChatService.sendMessage(
+        message: userMessage,
+        userVegetable: widget.userVegetable,
+        chatHistory: _messages.where((msg) => msg.message != 'こんにちは！野菜の栽培についてお答えします。何でもお聞きください！').toList(),
+      );
+      
+      setState(() {
+        _messages.add(ChatMessage(
+          message: response,
+          isUser: false,
+          timestamp: DateTime.now(),
+        ));
+        _isLoading = false;
+      });
+
+      _scrollToBottom();
+      
+      // 相談履歴を保存
+      await _saveChatHistory();
+      
+      // 送信可能状態に戻す（3秒後）
+      Future.delayed(const Duration(seconds: 3), () {
+        if (mounted) {
+          setState(() {
+            _canSend = true;
+          });
+        }
+      });
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+      });
+      
+      _handleError(e);
+      
+      // エラー時も一定時間後に送信可能にする
+      Future.delayed(const Duration(seconds: 5), () {
+        if (mounted) {
+          setState(() {
+            _canSend = true;
+          });
+        }
+      });
+    }
+  }
+
+  void _handleError(dynamic error) {
+    String message;
+    String actionText = 'OK';
+    VoidCallback? action;
+
+    if (error is RateLimitException) {
+      message = 'APIのレート制限に達しました。';
+      if (error.retryAfter != null) {
+        message += '\n${error.retryAfter}秒後に再試行してください。';
+      } else {
+        message += '\nしばらく時間をおいてから再試行してください。';
+      }
+      actionText = '詳細';
+      action = () => _showRateLimitDialog();
+    } else if (error is ApiException) {
+      message = 'API接続エラーが発生しました。\n再度お試しください。';
+    } else {
+      message = 'メッセージの送信に失敗しました。\nネットワーク接続を確認してください。';
+    }
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(message),
+          backgroundColor: error is RateLimitException ? Colors.orange : Colors.red,
+          duration: const Duration(seconds: 5),
+          action: action != null ? SnackBarAction(
+            label: actionText,
+            textColor: Colors.white,
+            onPressed: action,
+          ) : null,
+        ),
+      );
+    }
+  }
+
+  void _showRateLimitDialog() {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Row(
+          children: [
+            Icon(Icons.access_time, color: Colors.orange),
+            SizedBox(width: 8),
+            Text('レート制限について'),
+          ],
+        ),
+        content: const Text(
+          'OpenAI APIには利用制限があります。\n\n'
+          '対処法：\n'
+          '• 2-3分待ってから再試行\n'
+          '• 質問を簡潔にまとめる\n'
+          '• 連続でメッセージを送らない\n\n'
+          'ご理解とご協力をお願いします。',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('了解'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _saveChatHistory() async {
+    try {
+      await _consultationService.saveChatHistory(
+        userVegetableId: widget.userVegetable.id,
+        messages: _messages,
+      );
+    } catch (e) {
+      // エラーは無視（バックグラウンドで保存）
+    }
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          'AI相談',
+          style: AppTextStyles.subtitle1.copyWith(
+            color: Colors.white,
+          ),
+        ),
+        backgroundColor: AppColors.primary,
+        iconTheme: const IconThemeData(color: Colors.white),
+        elevation: 0,
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Container(
+              color: AppColors.background,
+              child: ListView.builder(
+                controller: _scrollController,
+                padding: const EdgeInsets.all(16),
+                itemCount: _messages.length + (_isLoading ? 1 : 0),
+                itemBuilder: (context, index) {
+                  if (index == _messages.length && _isLoading) {
+                    return _buildLoadingMessage();
+                  }
+                  
+                  return _buildMessageBubble(_messages[index]);
+                },
+              ),
+            ),
+          ),
+          _buildMessageInput(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMessageBubble(ChatMessage message) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Row(
+        mainAxisAlignment: message.isUser 
+            ? MainAxisAlignment.end 
+            : MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (!message.isUser) _buildAvatar(false),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: message.isUser 
+                    ? AppColors.primary 
+                    : Colors.white,
+                borderRadius: BorderRadius.circular(16),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.1),
+                    blurRadius: 4,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    message.message,
+                    style: AppTextStyles.body2.copyWith(
+                      color: message.isUser ? Colors.white : AppColors.onSurface,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    _formatTime(message.timestamp),
+                    style: AppTextStyles.caption.copyWith(
+                      color: message.isUser 
+                          ? Colors.white.withValues(alpha: 0.8)
+                          : AppColors.disabled,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          if (message.isUser) _buildAvatar(true),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLoadingMessage() {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildAvatar(false),
+          const SizedBox(width: 8),
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(16),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.1),
+                  blurRadius: 4,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(AppColors.primary),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '回答を生成中...',
+                  style: AppTextStyles.body2.copyWith(
+                    color: AppColors.onSurface,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAvatar(bool isUser) {
+    return CircleAvatar(
+      radius: 20,
+      backgroundColor: isUser ? AppColors.primary : AppColors.secondary,
+      child: Icon(
+        isUser ? Icons.person : Icons.smart_toy,
+        color: Colors.white,
+        size: 20,
+      ),
+    );
+  }
+
+  Widget _buildMessageInput() {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.1),
+            blurRadius: 4,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        child: Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _messageController,
+                decoration: InputDecoration(
+                  hintText: '質問を入力してください...',
+                  hintStyle: AppTextStyles.body2.copyWith(
+                    color: AppColors.disabled,
+                  ),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(24),
+                    borderSide: BorderSide(color: AppColors.divider),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(24),
+                    borderSide: BorderSide(color: AppColors.primary),
+                  ),
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 12,
+                  ),
+                ),
+                maxLines: null,
+                textInputAction: TextInputAction.send,
+                onSubmitted: (_) => _sendMessage(),
+                enabled: !_isLoading && _canSend,
+              ),
+            ),
+            const SizedBox(width: 8),
+            GestureDetector(
+              onTap: (_isLoading || !_canSend) ? null : _sendMessage,
+              child: Container(
+                width: 48,
+                height: 48,
+                decoration: BoxDecoration(
+                  color: (_isLoading || !_canSend) ? AppColors.disabled : AppColors.primary,
+                  borderRadius: BorderRadius.circular(24),
+                ),
+                child: _isLoading
+                    ? SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                        ),
+                      )
+                    : Icon(
+                        Icons.send,
+                        color: Colors.white,
+                        size: 20,
+                      ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatTime(DateTime dateTime) {
+    return '${dateTime.hour.toString().padLeft(2, '0')}:${dateTime.minute.toString().padLeft(2, '0')}';
+  }
+}
+

--- a/lib/screens/ai_chat/ai_chat_screen.dart
+++ b/lib/screens/ai_chat/ai_chat_screen.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../models/user_vegetable.dart';
+import '../../models/vegetable.dart';
 import '../../core/themes/app_colors.dart';
 import '../../core/themes/app_text_styles.dart';
 import '../../services/ai_chat_service.dart';
 import '../../services/consultation_service.dart';
+import '../../providers/vegetable_provider.dart';
 
 class AiChatScreen extends StatefulWidget {
   final UserVegetable userVegetable;
@@ -45,9 +48,15 @@ class _AiChatScreenState extends State<AiChatScreen> {
       
       setState(() {
         if (chatHistory.isEmpty) {
+          // VegetableProviderから野菜名を取得
+          final vegetableProvider = Provider.of<VegetableProvider>(context, listen: false);
+          final vegetable = vegetableProvider.getVegetableById(widget.userVegetable.vegetableId);
+          final vegetableName = vegetable?.name ?? '野菜';
+          final plantedDays = widget.userVegetable.daysSincePlanted;
+          
           _messages = [
             ChatMessage(
-              message: 'こんにちは！野菜の栽培についてお答えします。何でもお聞きください！',
+              message: 'こんにちは！$vegetableNameの栽培についてサポートします。植えてから$plantedDays日目ですね。栽培で気になることがあれば何でもお聞きください！',
               isUser: false,
               timestamp: DateTime.now(),
             ),
@@ -60,7 +69,7 @@ class _AiChatScreenState extends State<AiChatScreen> {
       setState(() {
         _messages = [
           ChatMessage(
-            message: 'こんにちは！野菜の栽培についてお答えします。何でもお聞きください！',
+            message: 'こんにちは！栽培についてサポートします。何でもお聞きください！',
             isUser: false,
             timestamp: DateTime.now(),
           ),
@@ -88,10 +97,15 @@ class _AiChatScreenState extends State<AiChatScreen> {
     _scrollToBottom();
 
     try {
+      // VegetableProviderから野菜情報を取得
+      final vegetableProvider = Provider.of<VegetableProvider>(context, listen: false);
+      final vegetable = vegetableProvider.getVegetableById(widget.userVegetable.vegetableId);
+      
       final response = await _aiChatService.sendMessage(
         message: userMessage,
         userVegetable: widget.userVegetable,
-        chatHistory: _messages.where((msg) => msg.message != 'こんにちは！野菜の栽培についてお答えします。何でもお聞きください！').toList(),
+        vegetable: vegetable,
+        chatHistory: _messages.where((msg) => !msg.message.startsWith('こんにちは！')).toList(),
       );
       
       setState(() {

--- a/lib/screens/vegetables/vegetable_detail_screen.dart
+++ b/lib/screens/vegetables/vegetable_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:go_router/go_router.dart';
 import '../../providers/vegetable_provider.dart';
 import '../../models/user_vegetable.dart';
 import '../../models/vegetable.dart';
@@ -120,8 +121,11 @@ class _VegetableDetailScreenState extends State<VegetableDetailScreen> {
           ),
           floatingActionButton: FloatingActionButton.extended(
             onPressed: () {
-              // TODO: AI相談画面に遷移
-              print('AI相談画面に遷移');
+              context.pushNamed(
+                'aiChat',
+                pathParameters: {'id': userVegetable.id},
+                extra: userVegetable,
+              );
             },
             backgroundColor: AppColors.secondary,
             foregroundColor: Colors.white,

--- a/lib/services/ai_chat_service.dart
+++ b/lib/services/ai_chat_service.dart
@@ -1,0 +1,219 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import '../models/user_vegetable.dart';
+
+class AiChatService {
+  static const String _baseUrl = 'https://api.openai.com/v1/chat/completions';
+  static const int _maxRetries = 3;
+  static const Duration _baseDelay = Duration(seconds: 2);
+
+  late final String _apiKey;
+  DateTime? _lastRequestTime;
+
+  AiChatService() {
+    _apiKey = dotenv.env['OPENAI_API_KEY'] ?? '';
+    if (_apiKey.isEmpty) {
+      throw Exception('OpenAI API key not found in environment variables');
+    }
+  }
+
+  Future<String> sendMessage({
+    required String message,
+    required UserVegetable userVegetable,
+    required List<ChatMessage> chatHistory,
+  }) async {
+    // レート制限対策：前回のリクエストから最低2秒待つ
+    await _enforceRateLimit();
+
+    Exception? lastException;
+
+    for (int attempt = 0; attempt < _maxRetries; attempt++) {
+      try {
+        final response = await http.post(
+          Uri.parse(_baseUrl),
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer $_apiKey',
+          },
+          body: jsonEncode({
+            'model': 'gpt-4o-mini',
+            'messages': _buildMessages(message, userVegetable, chatHistory),
+            'max_tokens': 1000,
+            'temperature': 0.7,
+          }),
+        );
+
+        _lastRequestTime = DateTime.now();
+
+        if (response.statusCode == 200) {
+          final data = jsonDecode(utf8.decode(response.bodyBytes));
+          return data['choices'][0]['message']['content'] as String;
+        } else if (response.statusCode == 429) {
+          // レート制限エラーの場合
+          final retryAfter = _getRetryAfterSeconds(response.headers);
+          final delay = Duration(
+            seconds: retryAfter ?? (2 << attempt),
+          ); // 指数バックオフ
+
+          if (attempt < _maxRetries - 1) {
+            await Future.delayed(delay);
+            continue;
+          } else {
+            throw RateLimitException(
+              'APIのレート制限に達しました。しばらく時間をおいてから再試行してください。',
+              retryAfter: retryAfter,
+            );
+          }
+        } else {
+          final errorData = jsonDecode(response.body);
+          throw ApiException(
+            'OpenAI API error: ${response.statusCode}',
+            statusCode: response.statusCode,
+            errorMessage: errorData['error']?['message'] ?? 'Unknown error',
+          );
+        }
+      } catch (e) {
+        lastException = e is Exception ? e : Exception(e.toString());
+
+        if (e is RateLimitException || e is ApiException) {
+          rethrow; // 特定のエラーはそのまま再スロー
+        }
+
+        if (attempt < _maxRetries - 1) {
+          await Future.delayed(Duration(seconds: 2 << attempt)); // 指数バックオフ
+          continue;
+        }
+      }
+    }
+
+    throw lastException ?? Exception('AI相談でエラーが発生しました');
+  }
+
+  Future<void> _enforceRateLimit() async {
+    if (_lastRequestTime != null) {
+      final timeSinceLastRequest = DateTime.now().difference(_lastRequestTime!);
+      if (timeSinceLastRequest < _baseDelay) {
+        await Future.delayed(_baseDelay - timeSinceLastRequest);
+      }
+    }
+  }
+
+  int? _getRetryAfterSeconds(Map<String, String> headers) {
+    final retryAfter = headers['retry-after'];
+    if (retryAfter != null) {
+      return int.tryParse(retryAfter);
+    }
+    return null;
+  }
+
+  List<Map<String, String>> _buildMessages(
+    String userMessage,
+    UserVegetable userVegetable,
+    List<ChatMessage> chatHistory,
+  ) {
+    final messages = <Map<String, String>>[];
+
+    // システムプロンプト
+    messages.add({
+      'role': 'system',
+      'content': _buildSystemPrompt(userVegetable),
+    });
+
+    // 過去の会話履歴を追加
+    for (final chat in chatHistory) {
+      if (chat.message.isNotEmpty) {
+        messages.add({
+          'role': chat.isUser ? 'user' : 'assistant',
+          'content': chat.message,
+        });
+      }
+    }
+
+    // 現在のユーザーメッセージ
+    messages.add({'role': 'user', 'content': userMessage});
+
+    return messages;
+  }
+
+  String _buildSystemPrompt(UserVegetable userVegetable) {
+    final plantedDays = userVegetable.daysSincePlanted;
+    final plantType = userVegetable.plantType.displayName;
+    final location = userVegetable.location.displayName;
+
+    return '''
+あなたは家庭菜園の専門家です。初心者にも分かりやすく、親しみやすい口調でアドバイスをしてください。
+
+栽培情報：
+- 植付タイプ: $plantType
+- 栽培場所: $location
+- 植えてからの日数: $plantedDays日
+
+回答の指針：
+1. 具体的で実践的なアドバイスを提供する
+2. 初心者でも理解しやすい言葉を使う
+3. 必要に応じて作業のタイミングや手順を説明する
+4. 症状がある場合は、可能な原因と対処法を複数提示する
+5. 安全性を重視し、農薬等の使用は慎重に案内する
+6. 150文字以内で簡潔に回答する
+
+口調：
+- 丁寧だが親しみやすい
+- 「〜です」「〜ますね」などの敬語
+- 「きっと」「おそらく」など、断定を避ける表現を適度に使う
+''';
+  }
+}
+
+class ChatMessage {
+  final String message;
+  final bool isUser;
+  final DateTime timestamp;
+
+  ChatMessage({
+    required this.message,
+    required this.isUser,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'message': message,
+      'is_user': isUser,
+      'timestamp': timestamp.toIso8601String(),
+    };
+  }
+
+  factory ChatMessage.fromJson(Map<String, dynamic> json) {
+    return ChatMessage(
+      message: json['message'] as String,
+      isUser: json['is_user'] as bool,
+      timestamp: DateTime.parse(json['timestamp'] as String),
+    );
+  }
+}
+
+class RateLimitException implements Exception {
+  final String message;
+  final int? retryAfter;
+
+  RateLimitException(this.message, {this.retryAfter});
+
+  @override
+  String toString() => message;
+}
+
+class ApiException implements Exception {
+  final String message;
+  final int statusCode;
+  final String errorMessage;
+
+  ApiException(
+    this.message, {
+    required this.statusCode,
+    required this.errorMessage,
+  });
+
+  @override
+  String toString() => '$message: $errorMessage';
+}

--- a/lib/services/consultation_service.dart
+++ b/lib/services/consultation_service.dart
@@ -1,0 +1,58 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../services/ai_chat_service.dart';
+
+class ConsultationService {
+  final SupabaseClient _supabase = Supabase.instance.client;
+
+  /// 相談履歴を保存
+  Future<void> saveChatHistory({
+    required String userVegetableId,
+    required List<ChatMessage> messages,
+  }) async {
+    try {
+      final messagesJson = messages.map((msg) => msg.toJson()).toList();
+      
+      await _supabase.from('consultations').upsert({
+        'user_vegetable_id': userVegetableId,
+        'messages': messagesJson,
+        'updated_at': DateTime.now().toIso8601String(),
+      });
+    } catch (e) {
+      throw Exception('相談履歴の保存に失敗しました: $e');
+    }
+  }
+
+  /// 相談履歴を取得
+  Future<List<ChatMessage>> getChatHistory(String userVegetableId) async {
+    try {
+      final response = await _supabase
+          .from('consultations')
+          .select('messages')
+          .eq('user_vegetable_id', userVegetableId)
+          .maybeSingle();
+
+      if (response == null || response['messages'] == null) {
+        return [];
+      }
+
+      final messagesJson = response['messages'] as List<dynamic>;
+      return messagesJson
+          .map((msg) => ChatMessage.fromJson(msg as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      throw Exception('相談履歴の取得に失敗しました: $e');
+    }
+  }
+
+  /// 相談履歴を削除
+  Future<void> deleteChatHistory(String userVegetableId) async {
+    try {
+      await _supabase
+          .from('consultations')
+          .delete()
+          .eq('user_vegetable_id', userVegetableId);
+    } catch (e) {
+      throw Exception('相談履歴の削除に失敗しました: $e');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- AI相談画面のUI実装（チャット形式）
- OpenAI GPT-4o-mini連携サービス
- 相談履歴のSupabase保存機能
- 429エラー対策（リトライ機能、レート制限制御）
- ユーザーフレンドリーなエラーハンドリング
- 野菜詳細画面からの遷移機能

## Test plan
- [x] 野菜詳細画面のAI相談ボタンから遷移できること
- [x] チャット形式でメッセージを送受信できること
- [x] OpenAI API連携が正常に動作すること
- [x] 429エラー時の適切なエラーハンドリング
- [x] 相談履歴の保存・読み込み機能
- [ ] レート制限対策の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI chat responses now include detailed, vegetable-specific advice based on the current growth stage and characteristics of your plant.
  * Initial greeting and chat interactions are dynamically tailored using your selected vegetable’s information.

* **Improvements**
  * Enhanced the friendliness and beginner supportiveness of AI chat responses.
  * System prompts are now more structured and informative, providing clearer guidance and tips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->